### PR TITLE
update commands cache if base not found and try again

### DIFF
--- a/xontrib/langenv_common.py
+++ b/xontrib/langenv_common.py
@@ -7,8 +7,14 @@ from os.path import join, exists
 from builtins import __xonsh__  # XonshSession (${...} is '__xonsh__.env')
 from xonsh.lib import subprocess as subproc
 
+is_cmd_cache_fresh = False
+
 def get_bin(base):
+    global is_cmd_cache_fresh
     bin = __xonsh__.commands_cache.lazy_locate_binary(base, ignore_alias=True)
+    if not bin and not is_cmd_cache_fresh:
+        is_cmd_cache_fresh = True
+        bin = __xonsh__.commands_cache.locate_binary( base, ignore_alias=True)
     if not bin:
         envx = __xonsh__.env
         PATH = envx.get("PATH")


### PR DESCRIPTION
but only for the first time

Sometimes can't find an existing command because commands cache isn't refreshed yet (not sure when exactly xonsh does that), so added a non-lazy search that auto-forces the refresh the first time we can't find any command (subsequently it's assumed that the cache is fresh and the command is really missing, might be expensive to refresh cache on every command)